### PR TITLE
Decode Chambers County's primary results

### DIFF
--- a/2016/Chambers-2016-primary-county.txt
+++ b/2016/Chambers-2016-primary-county.txt
@@ -1,0 +1,625 @@
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         STATISTICS                                               Report EL45A    Page 001                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+ PRECINCTS COUNTED (OF 13) .  .  .  .  .         13  100.00                                                                                                                      
+ REGISTERED VOTERS - TOTAL .  .  .  .  .     25,642                                                                                                                              
+ BALLOTS CAST - TOTAL.  .  .  .  .  .  .      8,146                   119         3,295         4,732                                                                            
+ BALLOTS CAST - REPUBLICAN PARTY .  .  .      7,101   87.17            81         2,954         4,066                                                                            
+ BALLOTS CAST - DEMOCRATIC PARTY .  .  .      1,045   12.83            38           341           666                                                                            
+ VOTER TURNOUT - TOTAL  .  .  .  .  .  .              31.77                                                                                                                      
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 002                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+President                                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Rick Santorum .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+ Chris Christie.  .  .  .  .  .  .  .  .          7     .10             1             4             2                                                                            
+ Jeb Bush.  .  .  .  .  .  .  .  .  .  .         45     .64             2            35             8                                                                            
+ Elizabeth Gray.  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+ Ted Cruz.  .  .  .  .  .  .  .  .  .  .      3,770   53.35            33         1,497         2,240                                                                            
+ Lindsey Graham.  .  .  .  .  .  .  .  .          2     .03             0             1             1                                                                            
+ Mike Huckabee .  .  .  .  .  .  .  .  .         12     .17             1             7             4                                                                            
+ Ben Carson .  .  .  .  .  .  .  .  .  .        228    3.23             2            83           143                                                                            
+ Donald J. Trump  .  .  .  .  .  .  .  .      2,037   28.83            25           920         1,092                                                                            
+ Rand Paul  .  .  .  .  .  .  .  .  .  .         17     .24             0             6            11                                                                            
+ Marco Rubio.  .  .  .  .  .  .  .  .  .        614    8.69            13           252           349                                                                            
+ John R. Kasich.  .  .  .  .  .  .  .  .        181    2.56             4            68           109                                                                            
+ Carly Fiorina .  .  .  .  .  .  .  .  .         46     .65             0            17            29                                                                            
+ Uncommitted.  .  .  .  .  .  .  .  .  .        107    1.51             0            48            59                                                                            
+         Total .  .  .  .  .  .  .  .  .      7,066                    81         2,938         4,047                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         35                     0            16            19                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+US Representative, Dist 36                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Brian Babin.  .  .  .  .  .  .  .  .  .      5,076  100.00            69         2,236         2,771                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,076                    69         2,236         2,771                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,025                    12           718         1,295                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Railroad Commissioner                                                                                                                                                            
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Ron Hale.  .  .  .  .  .  .  .  .  .  .      1,338   26.79            12           552           774                                                                            
+ Weston Martinez  .  .  .  .  .  .  .  .        257    5.15             2           104           151                                                                            
+ Doug Jeffrey  .  .  .  .  .  .  .  .  .        564   11.29             9           225           330                                                                            
+ John Greytok  .  .  .  .  .  .  .  .  .        262    5.25             9           113           140                                                                            
+ Wayne Christian  .  .  .  .  .  .  .  .      1,551   31.06            13           700           838                                                                            
+ Lance N. Christian  .  .  .  .  .  .  .        297    5.95             3           131           163                                                                            
+ Gary Gates .  .  .  .  .  .  .  .  .  .        725   14.52            13           347           365                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,994                    61         2,172         2,761                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,107                    20           782         1,305                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, Supreme Court, P3                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Debra Lehrmann.  .  .  .  .  .  .  .  .      2,431   47.02            26         1,076         1,329                                                                            
+ Michael Massengale  .  .  .  .  .  .  .      2,739   52.98            37         1,152         1,550                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,170                    63         2,228         2,879                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      1,931                    18           726         1,187                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 003                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Justice, Supreme Court, P5                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Paul Green .  .  .  .  .  .  .  .  .  .      3,079   62.10            45         1,307         1,727                                                                            
+ Rick Green .  .  .  .  .  .  .  .  .  .      1,879   37.90            19           817         1,043                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,958                    64         2,124         2,770                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,143                    17           830         1,296                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, Supreme Court, P9                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Joe Pool.  .  .  .  .  .  .  .  .  .  .      2,967   59.25            35         1,230         1,702                                                                            
+ Eva Guzman .  .  .  .  .  .  .  .  .  .      2,041   40.75            27           922         1,092                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,008                    62         2,152         2,794                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,093                    19           802         1,272                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Judge, Ct of Crim App, P2                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Chris Oldner  .  .  .  .  .  .  .  .  .      1,739   37.69            24           733           982                                                                            
+ Mary Lou Keel .  .  .  .  .  .  .  .  .      1,898   41.14            27           792         1,079                                                                            
+ Ray Wheless.  .  .  .  .  .  .  .  .  .        977   21.17            13           454           510                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,614                    64         1,979         2,571                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,487                    17           975         1,495                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Judge, Ct of Crim App, P5                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Steve Smith.  .  .  .  .  .  .  .  .  .      1,478   31.61            10           605           863                                                                            
+ Scott Walker  .  .  .  .  .  .  .  .  .      2,058   44.01            23           873         1,162                                                                            
+ Sid Harle  .  .  .  .  .  .  .  .  .  .        471   10.07            21           221           229                                                                            
+ Brent Webster .  .  .  .  .  .  .  .  .        669   14.31             9           304           356                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,676                    63         2,003         2,610                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,425                    18           951         1,456                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Judge, Ct of Crim App, P6                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Michael E. Keasler  .  .  .  .  .  .  .      2,615   57.00            38         1,153         1,424                                                                            
+ Richard Davis .  .  .  .  .  .  .  .  .      1,973   43.00            24           819         1,130                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,588                    62         1,972         2,554                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,513                    19           982         1,512                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+State Senator, District 4                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Brandon Creighton.  .  .  .  .  .  .  .      4,739  100.00            63         2,050         2,626                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,739                    63         2,050         2,626                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,362                    18           904         1,440                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 004                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+State Representative, District 23                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Wayne Faircloth  .  .  .  .  .  .  .  .      5,072  100.00            63         2,182         2,827                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,072                    63         2,182         2,827                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,029                    18           772         1,239                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Chief Justice, 1st Ct of Appeals Dist                                                                                                                                            
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Sherry Radack .  .  .  .  .  .  .  .  .      4,498  100.00            62         1,926         2,510                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,498                    62         1,926         2,510                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,603                    19         1,028         1,556                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, 1st Ct of Ap Dist, P4                                                                                                                                                   
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Evelyn Keyes  .  .  .  .  .  .  .  .  .      4,451  100.00            61         1,916         2,474                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,451                    61         1,916         2,474                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,650                    20         1,038         1,592                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, 14th Ct of Ap Dist, P2                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Kevin Jewell  .  .  .  .  .  .  .  .  .      3,369   73.95            49         1,434         1,886                                                                            
+ Bud Wiesedeppe.  .  .  .  .  .  .  .  .      1,187   26.05            15           532           640                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,556                    64         1,966         2,526                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,545                    17           988         1,540                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, 14th Ct of Ap Dist, P9                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Tracy Elizabeth Christopher  .  .  .  .      4,502  100.00            59         1,939         2,504                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,502                    59         1,939         2,504                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,599                    22         1,015         1,562                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+District Judge, 344th Judicial District                                                                                                                                          
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Randy McDonald.  .  .  .  .  .  .  .  .      4,776  100.00            60         2,084         2,632                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,776                    60         2,084         2,632                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,325                    21           870         1,434                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 005                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+District Attorney, 344th Dist                                                                                                                                                    
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Cheryl Swope Lieck  .  .  .  .  .  .  .      4,932  100.00            55         2,124         2,753                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,932                    55         2,124         2,753                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,169                    26           830         1,313                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Attorney                                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Alex Bill, III.  .  .  .  .  .  .  .  .      1,240   21.45            12           543           685                                                                            
+ Scott R. Peal .  .  .  .  .  .  .  .  .      4,541   78.55            55         1,962         2,524                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,781                    67         2,505         3,209                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      1,320                    14           449           857                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Sheriff                                                                                                                                                                          
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Brian C. Hawthorne  .  .  .  .  .  .  .      5,367  100.00            62         2,294         3,011                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,367                    62         2,294         3,011                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      1,734                    19           660         1,055                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Tax Assessor-Collector                                                                                                                                                    
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Denise Hutter .  .  .  .  .  .  .  .  .      5,354  100.00            62         2,274         3,018                                                                            
+         Total .  .  .  .  .  .  .  .  .      5,354                    62         2,274         3,018                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      1,747                    19           680         1,048                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Commissioner, Pct 1                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 5 OF 5 PRECINCTS COUNTED)                                                                                                                                              
+ Jimmy E. Gore .  .  .  .  .  .  .  .  .        783   51.18            13           345           425                                                                            
+ James G. Gibson  .  .  .  .  .  .  .  .        747   48.82             6           379           362                                                                            
+         Total .  .  .  .  .  .  .  .  .      1,530                    19           724           787                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         86                     2            33            51                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Commissioner, Pct 3                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ Gary R. Nelson.  .  .  .  .  .  .  .  .      1,419  100.00            20           650           749                                                                            
+         Total .  .  .  .  .  .  .  .  .      1,419                    20           650           749                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        542                     5           213           324                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 006                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Constable, Precinct No. 1                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ Dennis Dugat  .  .  .  .  .  .  .  .  .        753   70.37             7           408           338                                                                            
+ Jason Sonnier .  .  .  .  .  .  .  .  .        317   29.63             5           177           135                                                                            
+         Total .  .  .  .  .  .  .  .  .      1,070                    12           585           473                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         54                     0            21            33                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Constable, Precinct No. 2                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ Don Richard Langford.  .  .  .  .  .  .        542  100.00             6           213           323                                                                            
+         Total .  .  .  .  .  .  .  .  .        542                     6           213           323                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        124                     3            48            73                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Constable, Precinct No. 3                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ Donnie Standley  .  .  .  .  .  .  .  .        157  100.00             3            56            98                                                                            
+         Total .  .  .  .  .  .  .  .  .        157                     3            56            98                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         38                     1            12            25                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Constable, Precinct No. 4                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ Ben L. "Butch" Bean Jr..  .  .  .  .  .      1,440  100.00            20           650           770                                                                            
+         Total .  .  .  .  .  .  .  .  .      1,440                    20           650           770                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        521                     5           213           303                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Constable, Precinct No. 6                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 3 OF 3 PRECINCTS COUNTED)                                                                                                                                              
+ Robert Barrow .  .  .  .  .  .  .  .  .      2,104  100.00            14           815         1,275                                                                            
+         Total .  .  .  .  .  .  .  .  .      2,104                    14           815         1,275                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        679                     9           245           425                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Chairman                                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Eric Smith .  .  .  .  .  .  .  .  .  .      4,723  100.00            59         2,031         2,633                                                                            
+         Total .  .  .  .  .  .  .  .  .      4,723                    59         2,031         2,633                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .      2,378                    22           923         1,433                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 007                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Precinct Chairman, Precinct No. 11                                                                                                                                               
+Vote for  1                                                                                                                                                                      
+    (WITH 1 OF 1 PRECINCTS COUNTED)                                                                                                                                              
+ Allen Martin  .  .  .  .  .  .  .  .  .        404   61.87             2           191           211                                                                            
+ Kenneth "Spanky" Hampton  .  .  .  .  .        249   38.13             1           113           135                                                                            
+         Total .  .  .  .  .  .  .  .  .        653                     3           304           346                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        288                     2           112           174                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Democratic Party                                         Report EL45A    Page 008                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+President                                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Roque "Rocky" De La Fuente.  .  .  .  .          5     .49             0             1             4                                                                            
+ Calvis L. Hawes  .  .  .  .  .  .  .  .          3     .30             0             0             3                                                                            
+ Hillary Clinton  .  .  .  .  .  .  .  .        688   67.85            31           211           446                                                                            
+ Martin J. O'Malley  .  .  .  .  .  .  .          6     .59             0             3             3                                                                            
+ Willie L. Wilson .  .  .  .  .  .  .  .          7     .69             0             3             4                                                                            
+ Keith Judd .  .  .  .  .  .  .  .  .  .          3     .30             0             2             1                                                                            
+ Bernie Sanders.  .  .  .  .  .  .  .  .        295   29.09             5           108           182                                                                            
+ Star Locke .  .  .  .  .  .  .  .  .  .          7     .69             0             3             4                                                                            
+         Total .  .  .  .  .  .  .  .  .      1,014                    36           331           647                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         31                     2            10            19                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Railroad Commissioner                                                                                                                                                            
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Lon Burnam .  .  .  .  .  .  .  .  .  .        140   18.72             7            56            77                                                                            
+ Grady Yarbrough  .  .  .  .  .  .  .  .        396   52.94            24           121           251                                                                            
+ Cody Garrett  .  .  .  .  .  .  .  .  .        212   28.34             3            79           130                                                                            
+         Total .  .  .  .  .  .  .  .  .        748                    34           256           458                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        297                     4            85           208                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, Supreme Court, P3                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Mike Westergren  .  .  .  .  .  .  .  .        649  100.00            31           227           391                                                                            
+         Total .  .  .  .  .  .  .  .  .        649                    31           227           391                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        396                     7           114           275                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, Supreme Court, P5                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Dori Contreras Garza.  .  .  .  .  .  .        666  100.00            33           234           399                                                                            
+         Total .  .  .  .  .  .  .  .  .        666                    33           234           399                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        379                     5           107           267                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, Supreme Court, P9                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Savannah Robinson.  .  .  .  .  .  .  .        678  100.00            32           228           418                                                                            
+         Total .  .  .  .  .  .  .  .  .        678                    32           228           418                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        367                     6           113           248                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Democratic Party                                         Report EL45A    Page 009                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Judge, Ct of Crim App, P2                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Lawrence "Larry" Meyers.  .  .  .  .  .        658  100.00            33           230           395                                                                            
+         Total .  .  .  .  .  .  .  .  .        658                    33           230           395                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        387                     5           111           271                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Judge, Ct of Crim App, P5                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Betsy Johnson .  .  .  .  .  .  .  .  .        657  100.00            33           224           400                                                                            
+         Total .  .  .  .  .  .  .  .  .        657                    33           224           400                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        388                     5           117           266                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Judge, Ct of Crim App, P6                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Robert Burns  .  .  .  .  .  .  .  .  .        646  100.00            33           225           388                                                                            
+         Total .  .  .  .  .  .  .  .  .        646                    33           225           388                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        399                     5           116           278                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+State Representative, District 23                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Lloyd Criss.  .  .  .  .  .  .  .  .  .        638  100.00            33           223           382                                                                            
+         Total .  .  .  .  .  .  .  .  .        638                    33           223           382                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        407                     5           118           284                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Chief Justice, 1st Ct of Appeals Dist                                                                                                                                            
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Jim Peacock.  .  .  .  .  .  .  .  .  .        645  100.00            33           227           385                                                                            
+         Total .  .  .  .  .  .  .  .  .        645                    33           227           385                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        400                     5           114           281                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, 1st Ct of Ap Dist, P4                                                                                                                                                   
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Barbara Gardner  .  .  .  .  .  .  .  .        678  100.00            32           239           407                                                                            
+         Total .  .  .  .  .  .  .  .  .        678                    32           239           407                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        367                     6           102           259                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Democratic Party                                         Report EL45A    Page 010                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Justice, 14th Ct of Ap Dist, P2                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Jim Sharp  .  .  .  .  .  .  .  .  .  .        311   39.77            14           121           176                                                                            
+ Candance White.  .  .  .  .  .  .  .  .        471   60.23            20           148           303                                                                            
+         Total .  .  .  .  .  .  .  .  .        782                    34           269           479                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        263                     4            72           187                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Justice, 14th Ct of Ap Dist, P9                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Peter M. Kelly.  .  .  .  .  .  .  .  .        657  100.00            33           229           395                                                                            
+         Total .  .  .  .  .  .  .  .  .        657                    33           229           395                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        388                     5           112           271                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Commissioner, Pct 1                                                                                                                                                       
+Vote for  1                                                                                                                                                                      
+    (WITH 5 OF 5 PRECINCTS COUNTED)                                                                                                                                              
+ Joseph Booz, Sr. .  .  .  .  .  .  .  .        196  100.00             7            66           123                                                                            
+         Total .  .  .  .  .  .  .  .  .        196                     7            66           123                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        100                     2            33            65                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Constable, Precinct No. 1                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ Prince F. Evans, Sr..  .  .  .  .  .  .        140  100.00             6            49            85                                                                            
+         Total .  .  .  .  .  .  .  .  .        140                     6            49            85                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         62                     2            32            28                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Constable, Precinct No. 5                                                                                                                                                        
+Vote for  1                                                                                                                                                                      
+    (WITH 2 OF 2 PRECINCTS COUNTED)                                                                                                                                              
+ C. R. "Popeye" Oldham  .  .  .  .  .  .         61  100.00             0             9            52                                                                            
+         Total .  .  .  .  .  .  .  .  .         61                     0             9            52                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         14                     0             1            13                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+County Chairman                                                                                                                                                                  
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Mary Hamm  .  .  .  .  .  .  .  .  .  .        701  100.00            31           242           428                                                                            
+         Total .  .  .  .  .  .  .  .  .        701                    31           242           428                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        344                     7            99           238                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Republican Party                                         Report EL45A    Page 011                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Proposition 1                                                                                                                                                                    
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Yes  .  .  .  .  .  .  .  .  .  .  .  .      4,481   69.34            54         1,893         2,534                                                                            
+ No.  .  .  .  .  .  .  .  .  .  .  .  .      1,981   30.66            18           837         1,126                                                                            
+         Total .  .  .  .  .  .  .  .  .      6,462                    72         2,730         3,660                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        639                     9           224           406                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Proposition 2                                                                                                                                                                    
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Yes  .  .  .  .  .  .  .  .  .  .  .  .      4,111   62.25            36         1,706         2,369                                                                            
+ No.  .  .  .  .  .  .  .  .  .  .  .  .      2,493   37.75            39         1,070         1,384                                                                            
+         Total .  .  .  .  .  .  .  .  .      6,604                    75         2,776         3,753                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        497                     6           178           313                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Proposition 3                                                                                                                                                                    
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Yes  .  .  .  .  .  .  .  .  .  .  .  .      5,085   79.52            61         2,180         2,844                                                                            
+ No.  .  .  .  .  .  .  .  .  .  .  .  .      1,310   20.48            13           519           778                                                                            
+         Total .  .  .  .  .  .  .  .  .      6,395                    74         2,699         3,622                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        706                     7           255           444                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Proposition 4                                                                                                                                                                    
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ Yes  .  .  .  .  .  .  .  .  .  .  .  .      6,141   95.97            72         2,601         3,468                                                                            
+ No.  .  .  .  .  .  .  .  .  .  .  .  .        258    4.03             2           102           154                                                                            
+         Total .  .  .  .  .  .  .  .  .      6,399                    74         2,703         3,622                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        702                     7           251           444                                                                            
+SUMMARY REPT-GROUP DETAIL                          2016 Primary Elections                             CUMULATIVE - OFFICIAL                                                      
+                                                   Chambers County, Texas                                                                                                        
+                                                   March 1, 2016                                                                                                                 
+Run Date:04/04/16 03:46 PM                         Democratic Party                                         Report EL45A    Page 012                                             
+                                                                                                                                                                                 
+                                        TOTAL VOTES     %   MAIL-IN & MAN  EARLY VOTING  ELECTION DAY                                                                            
+                                                                                                                                                                                 
+Referenda Item #1                                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ For  .  .  .  .  .  .  .  .  .  .  .  .        861   90.06            28           285           548                                                                            
+ Against .  .  .  .  .  .  .  .  .  .  .         95    9.94             5            32            58                                                                            
+         Total .  .  .  .  .  .  .  .  .        956                    33           317           606                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         89                     5            24            60                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Referenda Item #2                                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ For  .  .  .  .  .  .  .  .  .  .  .  .        860   91.30            31           283           546                                                                            
+ Against .  .  .  .  .  .  .  .  .  .  .         82    8.70             3            34            45                                                                            
+         Total .  .  .  .  .  .  .  .  .        942                    34           317           591                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        103                     4            24            75                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Referenda Item #3                                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ For  .  .  .  .  .  .  .  .  .  .  .  .        834   87.61            32           287           515                                                                            
+ Against .  .  .  .  .  .  .  .  .  .  .        118   12.39             2            34            82                                                                            
+         Total .  .  .  .  .  .  .  .  .        952                    34           321           597                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         93                     4            20            69                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Referenda Item #4                                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ For  .  .  .  .  .  .  .  .  .  .  .  .        838   90.50            30           280           528                                                                            
+ Against .  .  .  .  .  .  .  .  .  .  .         88    9.50             3            28            57                                                                            
+         Total .  .  .  .  .  .  .  .  .        926                    33           308           585                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .        119                     5            33            81                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Referenda Item #5                                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ For  .  .  .  .  .  .  .  .  .  .  .  .        661   67.59            29           225           407                                                                            
+ Against .  .  .  .  .  .  .  .  .  .  .        317   32.41             4           103           210                                                                            
+         Total .  .  .  .  .  .  .  .  .        978                    33           328           617                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         67                     5            13            49                                                                            
+                                                                                                                                                                                 
+                                                                                                                                                                                 
+Referenda Item #6                                                                                                                                                                
+Vote for  1                                                                                                                                                                      
+    (WITH 13 OF 13 PRECINCTS COUNTED)                                                                                                                                            
+ For  .  .  .  .  .  .  .  .  .  .  .  .        784   82.61            25           266           493                                                                            
+ Against .  .  .  .  .  .  .  .  .  .  .        165   17.39             7            54           104                                                                            
+         Total .  .  .  .  .  .  .  .  .        949                    32           320           597                                                                            
+    Over Votes .  .  .  .  .  .  .  .  .          0                     0             0             0                                                                            
+   Under Votes .  .  .  .  .  .  .  .  .         96                     6            21            69                                                                            


### PR DESCRIPTION
Initially, the data looked like garbage; `file` said "data"; `file --mime` said `application/octet-stream; charset=binary`.
I opened it in a text editor and I happened to get a 185-column wide view on the source .WRK file, which revealed that it was the same format as, e.g. Austin County's flat ASCII file.

Unfortunately, it's county-wide primary results, not precinct-level results.